### PR TITLE
Declare user variable in loginWithEmail

### DIFF
--- a/src/js/auth.js
+++ b/src/js/auth.js
@@ -33,9 +33,9 @@ export const loginWithGoogle = async () => {
 export const loginWithEmail = async (email, password) => {
     try {
         const userCredential = await signInWithEmailAndPassword(auth, email, password);
-        currentUser = userCredential.user;
-        onLoginSuccess(userCredential.user); // Usar callback para login exitoso
-        return userCredential.user;
+        const user = userCredential.user;
+        onLoginSuccess(user); // Usar callback para login exitoso
+        return user;
     } catch (error) {
         onAuthError(error); // Usar callback para error de autenticación
         throw error;


### PR DESCRIPTION
## Summary
- Declare user credential in `loginWithEmail` and reuse the local variable

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68952ea9fba083239e1d949a73970f64