### PR TITLE
fix: remove undefined currentUser reference in loginWithEmail

### DIFF
--- a/src/js/auth.js
+++ b/src/js/auth.js
@@ -33,7 +33,6 @@ export const loginWithGoogle = async () => {
 export const loginWithEmail = async (email, password) => {
     try {
         const userCredential = await signInWithEmailAndPassword(auth, email, password);
-        currentUser = userCredential.user;
         onLoginSuccess(userCredential.user); // Usar callback para login exitoso
         return userCredential.user;
     } catch (error) {


### PR DESCRIPTION
## Summary
- avoid reference error by removing undefined `currentUser` assignment in email login helper

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68952c733ac083239741a0d316376955